### PR TITLE
Removes const_fn feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,3 @@ repository = "https://github.com/whitequark/rust-log_buffer"
 homepage = "https://github.com/whitequark/rust-log_buffer"
 documentation = "https://whitequark.github.io/rust-log_buffer/log_buffer"
 description = "A zero-allocation ring buffer for storing text logs"
-
-[features]
-const_fn = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(feature = "const_fn", feature(const_fn))]
 
 /// A ring buffer that stores UTF-8 text.
 ///
@@ -67,7 +66,6 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> LogBuffer<T> {
     /// The buffer is *not* cleared after creation, and contains whatever is in `storage`.
     /// The `clear()` method should be called before use.
     /// However, this function can be used in a static initializer.
-    #[cfg(feature = "const_fn")]
     pub const fn uninitialized(storage: T) -> LogBuffer<T> {
         LogBuffer { buffer: storage, position: 0 }
     }


### PR DESCRIPTION
Since this feature of Rust has stabilized, it can be removed. If left, compilation errors occur for users of the library on newer rust versions.